### PR TITLE
Graphite mod

### DIFF
--- a/keyboards/splitkb/kyria/keymaps/stefsmeets/definitions.h
+++ b/keyboards/splitkb/kyria/keymaps/stefsmeets/definitions.h
@@ -18,6 +18,7 @@ enum layers {
 #define QWERTY   DF(_QWERTY)
 #define COLEMAK  DF(_COLEMAK)
 #define CANARY   DF(_CANARY)
+#define GRPHT    DF(_GRPHT)
 #define GAME     DF(_GAME)
 
 #define GAME2    MO(_GAME2)

--- a/keyboards/splitkb/kyria/keymaps/stefsmeets/definitions.h
+++ b/keyboards/splitkb/kyria/keymaps/stefsmeets/definitions.h
@@ -3,7 +3,7 @@
 enum layers {
     _COLEMAK = 0,
     _QWERTY,
-    _CANARY,
+    _GRAPHITE,
     _GAME,
     _GAME2,
     _SYMBOL,
@@ -17,8 +17,7 @@ enum layers {
 // layer shortcuts
 #define QWERTY   DF(_QWERTY)
 #define COLEMAK  DF(_COLEMAK)
-#define CANARY   DF(_CANARY)
-#define GRPHT    DF(_GRPHT)
+#define GRAPHITE DF(_GRAPHITE)
 #define GAME     DF(_GAME)
 
 #define GAME2    MO(_GAME2)

--- a/keyboards/splitkb/kyria/keymaps/stefsmeets/keymap.c
+++ b/keyboards/splitkb/kyria/keymaps/stefsmeets/keymap.c
@@ -45,6 +45,13 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
     ),
 
+    [_GRPHT] = LAYOUT(
+      _______,    KC_Q,    KC_L,    KC_D,    KC_W,    KC_B,                                        KC_J,    KC_F,    KC_O,    KC_U, _______, _______,
+      _______,    KC_N,    KC_R,    KC_T,    KC_S,    KC_G,                                        KC_Y,    KC_H,    KC_A,    KC_E,    KC_I, _______,
+      _______,    KC_Z,    KC_X,    KC_M,    KC_C,    KC_V, _______, _______, _______, _______,    KC_K,    KC_P, _______, _______, _______, _______,
+                                 _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
+    ),
+
     [_GAME] = LAYOUT(
        KC_ESC,    KC_Q,    KC_W,    KC_F,    KC_P,    KC_B,                                        KC_J,    KC_L,    KC_U,    KC_Y, _______, _______,
       KC_LSFT,    KC_A,    KC_R,    KC_S,    KC_T,    KC_G,                                        KC_M,    KC_N,    KC_E,    KC_I,    KC_O, _______,
@@ -96,7 +103,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [_ADJUST] = LAYOUT(
       _______,    GAME, _______, KC_MPLY, KC_MUTE,  QWERTY,                                     UM(E11), UM(E12), UM(E13), UM(E14), UM(E15), UM(E16),
       _______, _______, KC_MPRV, KC_VOLU, KC_MNXT, COLEMAK,                                     UM(E21), UM(E22), UM(E23), UM(E24), UM(E25), UM(E26),
-      _______, _______, _______, KC_VOLD, _______,  CANARY, _______, _______, _______, _______, UM(E31), UM(E32), UM(E33), UM(E34), UM(E35), UM(E36),                                 _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
+      _______, _______, _______, KC_VOLD, _______,   GRPHT, _______, _______, _______, _______, UM(E31), UM(E32), UM(E33), UM(E34), UM(E35), UM(E36),                                 _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
     ),
 
 //  */

--- a/keyboards/splitkb/kyria/keymaps/stefsmeets/keymap.c
+++ b/keyboards/splitkb/kyria/keymaps/stefsmeets/keymap.c
@@ -25,9 +25,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // Base Layer: COLEMAK
 
     [_COLEMAK] = LAYOUT(
-       KC_ESC,    KC_Q,    KC_W,    KC_F,    KC_P,    KC_B,                                        KC_J,    KC_L,    KC_U,    KC_Y, KC_UNDS, KC_BSPC,
+       KC_ESC,    KC_Q,    KC_W,    KC_F,    KC_P,    KC_B,                                        KC_J,    KC_L,    KC_U,    KC_Y,  KC_GRV, KC_BSPC,
       SFT_TAB,    KC_A,    KC_R,    KC_S,    KC_T,    KC_G,                                        KC_M,    KC_N,    KC_E,    KC_I,    KC_O, SFT_QUO,
-      KC_LCTL,    KC_Z,    KC_X,    KC_C,    KC_D,    KC_V,  KC_GRV, COMPOSE, KC_PSCR, GO_BACK,    KC_K,    KC_H, KC_COMM,  KC_DOT, KC_SLSH,  KC_DEL,
+      KC_LCTL,    KC_Z,    KC_X,    KC_C,    KC_D,    KC_V, GO_BACK, COMPOSE, KC_PSCR,  KC_MEH,    KC_K,    KC_H, KC_COMM,  KC_DOT, KC_SLSH,  KC_DEL,
                                  KC_LGUI, KC_LALT, SYM_DEL,  KC_SPC, FUN_ENT, MSE_HME, OSM_SFT, NAV_END, KC_LEFT, KC_RGHT
     ),
 
@@ -38,18 +38,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
     ),
 
-    [_CANARY] = LAYOUT(
-      _______,    KC_W,    KC_L,    KC_Y,    KC_P,    KC_B,                                        KC_Z,    KC_F,    KC_U,    KC_O, _______, _______,
-      _______,    KC_C,    KC_R,    KC_S,    KC_T,    KC_G,                                        KC_M,    KC_N,    KC_E,    KC_A,    KC_I, _______,
-      _______,    KC_Q,    KC_J,    KC_V,    KC_D,    KC_K, _______, _______, _______, _______,    KC_X,    KC_H, _______, _______, _______, _______,
-                                 _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
-    ),
-
 // Based on:
 // https://github.com/rdavison/graphite-layout
 // https://www.reddit.com/r/KeyboardLayouts/comments/15zu2rn/sturdy_vs_nerps/jxjq139/
 // Keeps low pinky usage, zxcv on left hand, 12 key similar to colemak-dh
-    [_GRPHT] = LAYOUT(
+    [_GRAPHITE] = LAYOUT(
       _______,    KC_Q,    KC_L,    KC_D,    KC_W,    KC_B,                                        KC_J,    KC_F,    KC_U,    KC_O, _______, _______,
       _______,    KC_N,    KC_R,    KC_T,    KC_S,    KC_G,                                        KC_Y,    KC_H,    KC_E,    KC_A,    KC_I, _______,
       _______,    KC_Z,    KC_X,    KC_M,    KC_C,    KC_V, _______, _______, _______, _______,    KC_K,    KC_P, _______, _______, _______, _______,
@@ -107,7 +100,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [_ADJUST] = LAYOUT(
       _______,    GAME, _______, KC_MPLY, KC_MUTE,  QWERTY,                                     UM(E11), UM(E12), UM(E13), UM(E14), UM(E15), UM(E16),
       _______, _______, KC_MPRV, KC_VOLU, KC_MNXT, COLEMAK,                                     UM(E21), UM(E22), UM(E23), UM(E24), UM(E25), UM(E26),
-      _______, _______, _______, KC_VOLD, _______,   GRPHT, _______, _______, _______, _______, UM(E31), UM(E32), UM(E33), UM(E34), UM(E35), UM(E36),                                 _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
+      _______, _______, _______, KC_VOLD, _______,GRAPHITE, _______, _______, _______, _______, UM(E31), UM(E32), UM(E33), UM(E34), UM(E35), UM(E36),                                 _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
     ),
 
 //  */

--- a/keyboards/splitkb/kyria/keymaps/stefsmeets/keymap.c
+++ b/keyboards/splitkb/kyria/keymaps/stefsmeets/keymap.c
@@ -39,15 +39,19 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
 
     [_CANARY] = LAYOUT(
-      _______,    KC_W,    KC_L,    KC_Y,    KC_P,    KC_B,                                        KC_Z,    KC_F,    KC_O,    KC_U, _______, _______,
-      _______,    KC_C,    KC_R,    KC_S,    KC_T,    KC_G,                                        KC_M,    KC_N,    KC_E,    KC_I,    KC_A, _______,
+      _______,    KC_W,    KC_L,    KC_Y,    KC_P,    KC_B,                                        KC_Z,    KC_F,    KC_U,    KC_O, _______, _______,
+      _______,    KC_C,    KC_R,    KC_S,    KC_T,    KC_G,                                        KC_M,    KC_N,    KC_E,    KC_A,    KC_I, _______,
       _______,    KC_Q,    KC_J,    KC_V,    KC_D,    KC_K, _______, _______, _______, _______,    KC_X,    KC_H, _______, _______, _______, _______,
                                  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
     ),
 
+// Based on:
+// https://github.com/rdavison/graphite-layout
+// https://www.reddit.com/r/KeyboardLayouts/comments/15zu2rn/sturdy_vs_nerps/jxjq139/
+// Keeps low pinky usage, zxcv on left hand, 12 key similar to colemak-dh
     [_GRPHT] = LAYOUT(
-      _______,    KC_Q,    KC_L,    KC_D,    KC_W,    KC_B,                                        KC_J,    KC_F,    KC_O,    KC_U, _______, _______,
-      _______,    KC_N,    KC_R,    KC_T,    KC_S,    KC_G,                                        KC_Y,    KC_H,    KC_A,    KC_E,    KC_I, _______,
+      _______,    KC_Q,    KC_L,    KC_D,    KC_W,    KC_B,                                        KC_J,    KC_F,    KC_U,    KC_O, _______, _______,
+      _______,    KC_N,    KC_R,    KC_T,    KC_S,    KC_G,                                        KC_Y,    KC_H,    KC_E,    KC_A,    KC_I, _______,
       _______,    KC_Z,    KC_X,    KC_M,    KC_C,    KC_V, _______, _______, _______, _______,    KC_K,    KC_P, _______, _______, _______, _______,
                                  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
     ),


### PR DESCRIPTION
Graphite with zqb rotation, j swap.

```
q l d w b  j f u o `
n r t s g  y h e a i
z x m c v  k p , . /

Sfb:  1.146%
Dsfb: 6.655%
Finger Speed: 5.893
    [0.093, 0.504, 0.754, 1.538, 0.774, 1.163, 1.043, 0.024]
Scissors: 0.200%
Lsbs: 1.089%

Inrolls: 20.416%
Outrolls: 23.253%
Total Rolls: 43.669%
Onehands: 1.167%

Alternates: 33.096%
Alternates (sfs): 8.286%
Total Alternates: 41.382%

Redirects: 2.281%
Redirects Sfs: 0.824%
Bad Redirects: 0.174%
Bad Redirects Sfs: 0.089%
Total Redirects: 3.368%

Bad Sfbs: 0.474%
Sft: 0.028%

Score: -0.300
```

